### PR TITLE
#23/AuthAPI

### DIFF
--- a/frontend/src/api/auth.api.ts
+++ b/frontend/src/api/auth.api.ts
@@ -12,9 +12,9 @@ export interface SignupProps {
 }
 
 export const login = (data: LoginProps) => {
-  return requestHandler("post", "/auth/login", data);
+  return requestHandler("post", "/users/login", data);
 };
 
 export const signup = (data: SignupProps) => {
-  return requestHandler("post", "/auth/signup", data);
+  return requestHandler("post", "/users/signup", data);
 };

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosRequestConfig } from "axios";
 import { getToken, removeToken } from "@/store/authStore";
 
-const BASE_URL = process.env.PORT_NUMBER;
+const BASE_URL = process.env.REACT_APP_BASE_URL;
 const DEFAULT_TIMEOUT = 30000;
 
 export const createClient = (config?: AxiosRequestConfig) => {

--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -1,10 +1,13 @@
 import { styled } from "styled-components";
 import { FaRegUser, FaSignInAlt } from "react-icons/fa";
 import { Link } from "react-router-dom";
-import { useState } from "react";
+import { useAuthStore } from "@/store/authStore";
+import { useAuth } from "@/hooks/useAuth";
 
 const Header = () => {
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  // const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const { isLoggedIn } = useAuthStore();
+  const { userLogout } = useAuth();
   return (
     <HeaderStyle>
       <nav className="navigation">
@@ -24,7 +27,7 @@ const Header = () => {
         {isLoggedIn ? (
           <ul>
             <li>
-              <button>로그아웃</button>
+              <button onClick={() => userLogout()}>로그아웃</button>
             </li>
           </ul>
         ) : (

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -9,7 +9,7 @@ export const useAuth = () => {
   const { showAlert } = useAlert();
   const navigate = useNavigate();
 
-  const { storeLogin } = useAuthStore();
+  const { storeLogin, storeLogout } = useAuthStore();
 
   const userLogin = async (data: LoginProps) => {
     try {
@@ -19,6 +19,16 @@ export const useAuth = () => {
       navigate("/");
     } catch (error) {
       showAlert("로그인이 실패했습니다.");
+    }
+  };
+
+  const userLogout = async () => {
+    try {
+      storeLogout();
+      showAlert("로그아웃이 완료되었습니다.");
+      navigate("/");
+    } catch (error) {
+      showAlert("로그아웃에 실패하였습니다.");
     }
   };
 
@@ -34,6 +44,7 @@ export const useAuth = () => {
 
   return {
     userLogin,
+    userLogout,
     userSignup,
   };
 };

--- a/frontend/src/pages/Signup.tsx
+++ b/frontend/src/pages/Signup.tsx
@@ -58,9 +58,11 @@ const Signup = () => {
               <p className="error-text">6자 이상 입력해주세요.</p>
             )}
           </fieldset>
-          <Button type="submit" size="medium" scheme="primary">
-            회원가입
-          </Button>
+          <fieldset>
+            <Button type="submit" size="medium" scheme="primary">
+              회원가입
+            </Button>
+          </fieldset>
         </form>
       </LoginStyle>
     </>

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 
-interface StoreState {
-  isloggedIn: boolean;
+interface AuthState {
+  isLoggedIn: boolean;
   storeLogin: (token: string) => void;
   storeLogout: () => void;
 }
@@ -19,14 +19,14 @@ export const removeToken = () => {
   localStorage.removeItem("token");
 };
 
-export const useAuthStore = create<StoreState>((set) => ({
-  isloggedIn: getToken() ? true : false,
+export const useAuthStore = create<AuthState>((set) => ({
+  isLoggedIn: getToken() ? true : false,
   storeLogin: (token: string) => {
-    set({ isloggedIn: true });
+    set({ isLoggedIn: true });
     setToken(token);
   },
   storeLogout: () => {
-    set({ isloggedIn: false });
+    set({ isLoggedIn: false });
     removeToken();
   },
 }));


### PR DESCRIPTION
## Overview

회원 관련 API 연동 완료

### Related Issue

Issue Number : #22 

## Task Details

- 회원가입 API 연결을 완료했습니다.
- 로그인 API 연결을 완료했습니다.
- 로그인 여부에 따라 헤더에 보여지는 것을 변경하였습니다. (비로그인 시 로그인/회원가입, 로그인 시 로그아웃)
- @/store/authStore의 getToken() 함수를 통해 토큰을 사용할 수 있습니다.

## Screenshots (Optional)


## Test Scope & Checklist (Optional)

- [ ] 회원가입, 로그인, 로그아웃이 잘 된다.
- [ ] 로그인 여부에 따라 헤더의 버튼이 다르게 보인다.

## Review Requirements

