### PR TITLE
#35/Add cash_after balance to TransactionList

### DIFF
--- a/frontend/src/components/transaction/TransactionList.tsx
+++ b/frontend/src/components/transaction/TransactionList.tsx
@@ -12,14 +12,8 @@ const TransactionList = () => {
     selectTransaction,
   } = useTransactionStore();
 
-  const { cash, fetchAssets } = useAssetStore();
-
   useEffect(() => {
     fetchTransactions();
-  }, []);
-
-  useEffect(() => {
-    fetchAssets();
   }, []);
 
   return (
@@ -68,7 +62,9 @@ const TransactionList = () => {
                   <span className={`price ${isBuy ? "buy" : "sell"}`}>
                     {signedPrice}
                   </span>
-                  <span className="balance">${cash.toLocaleString()}</span>
+                  <span className="balance">
+                    ${tx.cash_after.toLocaleString()}
+                  </span>
                 </div>
               </div>
             </li>

--- a/frontend/src/types/transaction.type.ts
+++ b/frontend/src/types/transaction.type.ts
@@ -6,4 +6,5 @@ export interface Transaction {
   symbol: string;
   company_name: string;
   created_at: string;
+  cash_after: number;
 }


### PR DESCRIPTION
## Overview
거래 내역에서 거래 후 잔액 출력 완료

### Related Issue
Issue Number : #35 

## Task Details
- 거래 내역 리스트 항목에 거래 후 잔액(cash_after) 표시

## Screenshots (Optional)
<img width="411" alt="스크린샷 2025-06-09 21 00 38" src="https://github.com/user-attachments/assets/a9201430-fe7e-44c1-8d8d-e91e7ee89098" />

## Test Scope & Checklist (Optional)
- [x] 거래 내역 리스트에서 거래 후 잔액이 잘 출력됨


## Review Requirements
